### PR TITLE
Rename 'tags' to 'tagsStr' in issue scripts

### DIFF
--- a/js/addIssue.js
+++ b/js/addIssue.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
 		console.log(obj.resolved);
 		obj.refs = $("#references").val();
 		//obj.refs = jsonArray($("#references").val());
-		obj.tags = $("#tags").val();
+		obj.tagsStr = $("#tags").val();
 
 		var jsonData = JSON.stringify(obj);
 		console.log(jsonData);

--- a/js/createIssue.js
+++ b/js/createIssue.js
@@ -14,7 +14,7 @@ $(document).ready(function() {
 		obj.resolved = isResolved;
 		console.log(obj.resolved);
 		obj.references = jsonArray($("#references").val());
-		obj.tags = jsonArray($("#tags").val());
+		obj.tagsStr = jsonArray($("#tags").val());
 
 		var jsonData = JSON.stringify(obj);
 		console.log(jsonData);


### PR DESCRIPTION
Updated both addIssue.js and createIssue.js to use 'tagsStr' instead of 'tags' when assigning tag values to the issue object. This change improves consistency in how tag data is referenced and serialized.